### PR TITLE
Output scheduled date in user's locale

### DIFF
--- a/remind/main.swift
+++ b/remind/main.swift
@@ -123,7 +123,8 @@ struct Notifier: ParsableCommand {
 
         note.deliveryDate = try Date.dateWith(d: days, h: hours, minutes: minutes, format: when)
         let formatter = DateFormatter()
-        formatter.dateFormat = "MM/dd/y HH:mm"
+        formatter.dateStyle = .short
+        formatter.locale = Locale.current
         if let deliveryDate = note.deliveryDate {
             let dateString = formatter.string(from: deliveryDate)
             print("Scheduling note for \(dateString).")


### PR DESCRIPTION
Output the "scheduling note for ..." date in the user's locale, so it makes sense to us Europeans too.